### PR TITLE
Skip standalone output on Vercel to fix failing production deploys

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
+// Vercel does its own packaging and its build step fails on standalone output
+// with Next 16.3.x, looking for a .next/next-server.js.nft.json it cannot
+// find. The Dockerfile copies .next/standalone, so keep emitting it everywhere
+// except on Vercel.
 const nextConfig: NextConfig = {
-  output: 'standalone',
+  ...(process.env.VERCEL ? {} : { output: "standalone" as const }),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem

Production deployments have failed since #25 (`next` 16.2.12 -> 16.3.3) landed. The build succeeds, then Vercel's packaging step fails:

```
✓ Compiled successfully in 3.7s
  Running TypeScript ... Finished TypeScript in 3.5s
✓ Generating static pages using 1 worker (3/3) in 171ms
  Finalizing page optimization ...
  Running onBuildComplete from Vercel
> Build error occurred
Error: ENOENT: no such file or directory, open '/vercel/path0/.next/next-server.js.nft.json'
Error: Command "npm run build" exited with 1
```

The history on `main` shows the boundary: #24 was 4/4 green, #25 and everything after is 3/4.

## Root cause

The trigger is `output: 'standalone'` combined with Next 16.3.x, **not** 16.3.x by itself.

The comparison that pins it down: `Pradumnasaraf.github.io` runs next `^16.3.2` and deploys green on Vercel. The only relevant difference is that it does not set `output: 'standalone'`. This repo does, and it fails.

The file is also not genuinely missing. A local `next build` on 16.3.3 produces `.next/next-server.js.nft.json` either way. Only Vercel's build step cannot find it.

## Fix

Vercel packages the app itself, so standalone output is redundant there. The Dockerfile does need it (line 29, `COPY --from=builder /app/.next/standalone ./`), so keep emitting it everywhere except on Vercel, which sets `VERCEL` in its build environment.

```ts
const nextConfig: NextConfig = {
  ...(process.env.VERCEL ? {} : { output: "standalone" as const }),
};
```

This keeps next on 16.3.3 rather than reverting it, and leaves the Docker image path intact.

## Verification

Local, next 16.3.3, both paths:

| build | standalone dir | nft.json | result |
|---|---|---|---|
| `VERCEL=1 npm run build` | absent, as intended | present | compiles, prerenders 3/3 |
| `npm run build` | `.next/standalone/server.js` present | present | compiles, prerenders 3/3 |

So the Vercel path now matches the shape of the repo that deploys green, and the Docker path still gets the directory it copies.

I could not build the Docker image itself (no local Docker daemon), only confirm the artifact it copies is produced.

The Preview deployment on this PR is the real test. Green Preview means production goes green on merge.

## Note

Opened as a PR rather than pushed to `main` so Preview validates this before it reaches production.

The branch name is left over from an earlier approach that pinned next back to 16.2.12; that is no longer what this PR does.
